### PR TITLE
fix bug

### DIFF
--- a/src/tmux_language_server/utils.py
+++ b/src/tmux_language_server/utils.py
@@ -15,7 +15,8 @@ SCHEMAS = {}
 QUERIES = {}
 language = Language(get_language_ptr())
 parser = Parser()
-parser.set_language(language)
+
+parser.language = language
 
 
 def get_query(name: str, filetype: FILETYPE = "tmux") -> Query:


### PR DESCRIPTION
i had error and fixed it

```
❯ tmux-language-server
Traceback (most recent call last):
  File "/sbin/tmux-language-server", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.12/site-packages/tmux_language_server/__main__.py", line 111, in main
    from .server import TmuxLanguageServer
  File "/usr/lib/python3.12/site-packages/tmux_language_server/server.py", line 30, in <module>
    from .finders import DIAGNOSTICS_FINDER_CLASSES, ImportTmuxFinder
  File "/usr/lib/python3.12/site-packages/tmux_language_server/finders.py", line 11, in <module>
    from .utils import get_query, get_schema
  File "/usr/lib/python3.12/site-packages/tmux_language_server/utils.py", line 18, in <module>
    parser.set_language(language)
    ^^^^^^^^^^^^^^^^^^^
AttributeError: 'tree_sitter.Parser' object has no attribute 'set_language'
❯ AttributeError: 'tree_sitter.Parser' object has no attribute 'set_language'
```
fix:
```python
parser.set_language(language)
```
to
```python
parser.language = language
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the configuration method for the parser language assignment for improved clarity and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->